### PR TITLE
Passing redis options is broken

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ function server(config = {}) {
             });
             const io = Socket(server, socketOpts);
 
-            const { redis: options = {} } = config;
+            const options = config.redis && config.redis.options || {};
             const client = redis.createClient(options);
             client.on('ready', () => {
                 client.subscribe('stats');


### PR DESCRIPTION
According to Docs, `config` looks like
```
const config = {
    redis: {
        driver: 'redis',
        options: {
            host: '127.0.0.1',
            port: 6379,
            connect_timeout: 3600000,
        }
    },
    monitor: {
        enabled: true,
        host: '127.0.0.1',
        port: 3000,
    },
};
```

Currently `redis.createClient` gets wrong options, which leads it to always use `default redis host and port`

So with
`const { redis: options = {} } = config;`, 

```
// we end up having
const options = {
  driver: 'redis',
  options: { 
    host: 'REDIS_HOST', 
    port: REDIS_PORT, 
    connect_timeout: CONNECT_TIMEOUT
  } 
}
const client = redis.createClient(options);
// leads to using default redis host and port all the time
```


